### PR TITLE
Switches extractNameKinda over to using a Parser.

### DIFF
--- a/psc-package.json
+++ b/psc-package.json
@@ -3,6 +3,8 @@
     "set": "aff-4.0-27-Oct-2017",
     "source": "https://github.com/justinwoo/package-sets.git",
     "depends": [
+        "bifunctors",
+        "string-parsers",
         "io",
         "aff",
         "halogen-css",


### PR DESCRIPTION
(Addresses #3.)

No tests committed yet; I've manually tested with the following:
```
> import FrontEnd as F
> import Types (Path(..))
> map (F.extractNameKinda <<< Path) [
  "[HorribleSubs] BlahTastic - 01 [720p].mkv",
  "[HorribleSubs] Blah BlahTastic - Whatever 01 [720p].mkv",
  "[HorribleSubs] Blah Blah BlahTastic - Legend of Blah.mkv",
  "[WorseSubs] Yeah Nah.mkv"
]
```

Producing:
```
[ (Right "BlahTastic"),
  (Right "Blah BlahTastic"),
  (Right "Blah Blah BlahTastic")
  (Left "Character '.' did not satisfy predicate")
]
```

(I can swap the error back to the original with a `const "didn't match expected patterns"` instead of `show` if you'd prefer.)